### PR TITLE
Basic support for ChimeraX attributes

### DIFF
--- a/docs/source/commands/qscore.rst
+++ b/docs/source/commands/qscore.rst
@@ -100,3 +100,13 @@ will have a score of N/A in all categories.
 
 If given, the same details as above will be written in comma-separated 
 text (CSV) format to a file of that name.
+
+**assignAttr**
+---------------
+
+If given, each selected atom will have the "qscore" attribute assigned to
+enable atom selection based on their score. For instance to select all atoms with qscore below 0.25:
+
+.. code-block::
+
+    select @@qscore<0.25

--- a/docs/source/commands/qscore.rst
+++ b/docs/source/commands/qscore.rst
@@ -105,8 +105,20 @@ text (CSV) format to a file of that name.
 ---------------
 
 If given, each selected atom will have the "qscore" attribute assigned to
-enable atom selection based on their score. For instance to select all atoms with qscore below 0.25:
+enable atom selection based on their score. For instance to select all atoms with Q-score below 0.25:
 
 .. code-block::
 
     select @@qscore<0.25
+	
+You can also use the "Render/Select by Attribute" tool to visualize Q-scores or run the following command:
+
+.. code-block::
+    
+	color byattribute qscore palette red:gray:blue range 0,1
+	
+Finally, the attribute assignment file can be saved with this command:
+
+.. code-block::
+    
+    save my_file.defattr attrName qscore

--- a/src/cmd.py
+++ b/src/cmd.py
@@ -5,13 +5,12 @@ from chimerax.core.commands import (
 )
 from chimerax.map import MapArg
 from chimerax.atomic import ResiduesArg
-
+from chimerax.core.errors import UserError
 
 def qscore(session, residues, to_volume=None, use_gui=True, reference_gaussian_sigma=0.6, points_per_shell=8, 
             max_shell_radius=2.0, shell_radius_step=0.1, include_hydrogens=False, randomize_shell_points=True,
-            log_details=False, output_file=None):
+            log_details=False, output_file=None, assign_attr=False):
     if to_volume is None:
-        from chimerax.core.errors import UserError
         raise UserError("Must specify a map to compare the model to!")
     if use_gui:
         if not session.ui.is_gui:
@@ -46,7 +45,7 @@ def qscore(session, residues, to_volume=None, use_gui=True, reference_gaussian_s
                                         randomize_shell_points=randomize_shell_points, 
                                         logger=session.logger,
                                         log_details=log_details,
-                                        output_file=output_file
+                                        output_file=output_file, assign_attr=assign_attr
                                         )
     if not use_gui:
         # The GUI itself runs this command with use_gui=False, so if we don't do this the result gets printed twice
@@ -68,6 +67,7 @@ qscore_desc = CmdDesc(
         ("max_shell_radius", Bounded(FloatArg, min=0.5, max=2.5)),
         ("shell_radius_step", Bounded(FloatArg, min=0.025, max=0.5)),
         ("log_details", BoolArg),
-        ("output_file", FileNameArg)
+        ("output_file", FileNameArg),
+        ("assign_attr", BoolArg),
     ]
     )

--- a/src/ui.py
+++ b/src/ui.py
@@ -306,10 +306,13 @@ class QScoreWidget(QFrame):
         if self._selected_model is None:
             raise UserError('No model is currently selected!')
         # ask for file path
-        filename = QFileDialog.getSaveFileName(self, 'Save attribute assignment file...', '.', '*.defattr')
-        
-        if filename is not None:
-            run_chimerax_command(self.session, f'save {filename[0]} attrName qscore models #{self._selected_model.id_string}')
+        # a tuple with two empty strings is retured by QFileDialog.getSaveFileName if the user presses Cancel
+        filename, _ = QFileDialog.getSaveFileName(self, 'Save attribute assignment file...', '.', '*.defattr')
+        if filename != "": 
+            if not filename.endswith('.defattr'):
+                # auto-add file suffix
+                filename += '.defattr'
+            run_chimerax_command(self.session, f'save "{filename}" attrName qscore models #{self._selected_model.id_string} format defattr')
 
     def update_plot(self, *_):
         pw = self.plot_widget
@@ -888,3 +891,4 @@ def slot_disconnected(signal, slot):
         pass
     finally:
         signal.connect(slot)
+        

--- a/src/ui.py
+++ b/src/ui.py
@@ -162,6 +162,12 @@ class QScoreWidget(QFrame):
 
         bhl.addWidget(ldcb, 1, 2)
 
+        aacb = self._assign_attr_checkbox = QCheckBox('Assign atom attr.')
+        aacb.setToolTip('<span>If checked, each atom will have the attribute "qscore" assigned to enable selection of residues based on the score.</span>')
+        aacb.setChecked(False)
+        bhl.addWidget(aacb, 1, 3)
+
+
         bl1.addLayout(bhl)
         bl1.addStretch()
         layout.addLayout(bl)
@@ -207,10 +213,14 @@ class QScoreWidget(QFrame):
     def log_details(self, flag):
         self._log_details_checkbox.setChecked(flag)
     
-
-
-
-
+    @property
+    def assign_attr(self):
+        'returns checked status of the tichbox about attribute assignment'
+        return self._assign_attr_checkbox.isChecked()
+    
+    @assign_attr.setter
+    def assign_attr(self, flag):
+        self._assign_attr_checkbox.setChecked(flag)
 
     def recalc(self, *_, log_details=None, output_file=None, echo_command=True):
         if log_details is None:
@@ -224,7 +234,7 @@ class QScoreWidget(QFrame):
             outputfile_text = f'outputFile {output_file}'
         else:
             outputfile_text = ''
-        residue_map, (query_atoms, atom_scores) = run(self.session, f'qscore #{m.id_string} to #{v.id_string} useGui false pointsPerShell {self.points_per_shell} shellRadiusStep {self.shell_radius_step:.3f} maxShellRadius {self.max_shell_radius:.2f} referenceGaussianSigma {self.reference_sigma:.2f} logDetails {log_details} {outputfile_text}', log=echo_command)
+        residue_map, (query_atoms, atom_scores) = run(self.session, f'qscore #{m.id_string} to #{v.id_string} useGui false pointsPerShell {self.points_per_shell} shellRadiusStep {self.shell_radius_step:.3f} maxShellRadius {self.max_shell_radius:.2f} referenceGaussianSigma {self.reference_sigma:.2f} logDetails {log_details} {outputfile_text} assignAttr {self.assign_attr}', log=echo_command)
         self._residue_map = residue_map
         self._atom_scores = atom_scores
         self._query_atoms = query_atoms


### PR DESCRIPTION
My five cents for #5 :
* a tick-box and a corresponding command-line option added to define and assign attribute "qscore" to atoms; this enables the use of Render/Select by attribute tool in ChimeraX to explore and visualize the Q-score in the context of the structure. Furthermore, the Q-scores are preserved when a ChimeraX session is saved
* a button to save [attribute file](https://www.cgl.ucsf.edu/chimerax/docs/user/formats/defattr.html) was added. It's a simple tab-separated file that can be parsed in other tools (even Excel). It can be also used to re-assign Q-scores to a PDB file. Pro-tip: if you need to assign the Q-score as the B-factor in the PDB file, you just need to change "qscore" to "bfactor" in the defattr file. Then the PDB file can be saved and visualized elsewhere (e.g. PyMOL)
* tool documentation was updated accordingly
* moved some redundant import statements to the top of the source code file

I hope this will be helpful!